### PR TITLE
Fix multiple typos and spelling mistakes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flask-CKEditor
 
-CKEditor integration for Flask, including image upload, code syntax highlight and more.
+CKEditor integration for Flask, including image upload, code syntax highlighting and more.
 
 ## Links
 

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,7 +1,7 @@
 <h3>About</h3>
 <p>
   CKEditor integration for Flask, add support to image upload, code syntax
-highlight and more.
+highlighting and more.
 </p>
 <h3>Useful Links</h3>
 <ul>

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -41,7 +41,7 @@ a CKEditor object and then separately initialize it for an app:
 Include CKEditor Resources
 --------------------------
 
-In the template which you want to put a CKEditor textarea, call ``ckeditor.load()``
+In the template in which you want to put a CKEditor textarea, call ``ckeditor.load()``
 in ``<head></head>`` or before ``</body>``:
 
 .. code-block:: jinja
@@ -51,7 +51,7 @@ in ``<head></head>`` or before ``</body>``:
        {{ ckeditor.load() }}
    </body>
 
-In default, it will load the CKEditor resources from CND (cdn.ckeditor.com), you can set ``CKEDITOR_SERVE_LOCAL``
+By default, it will load the CKEditor resources from CND (cdn.ckeditor.com), you can set ``CKEDITOR_SERVE_LOCAL``
 to True to use built-in resources. You can use ``custom_url`` to load your custom CKEditor build:
 
 .. code-block:: jinja
@@ -59,7 +59,7 @@ to True to use built-in resources. You can use ``custom_url`` to load your custo
    {{ ckeditor.load(custom_url=url_for('static', filename='ckeditor/ckeditor.js')) }}
 
 
-CKEditor provide three type of preset (i.e. ``basic``, ``standard`` and ``full``), this method default to load ``standard``.
+CKEditor provides three types of preset (i.e. ``basic``, ``standard`` and ``full``), this method defaults to load ``standard``.
 You can use `pkg_type` parameter or ``CKEDITOR_PKG_TYPE`` configuration variable to set the package type. For example:
 
 .. code-block:: jinja
@@ -96,7 +96,7 @@ It's quite simple, just call ``ckeditor.create()`` in the template:
 Get the Data
 ------------
 
-Since the CKEditor textarea is just a normal ``<textarea>`` element, so you can get the data
+Since the CKEditor textarea is just a normal ``<textarea>`` element, you can get the data
 from ``request.form`` by passing ``ckeditor`` as key:
 
 .. code-block:: python

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,8 +5,8 @@ Configuration
 Register Configuration
 -----------------------
 
-Except ``CKEDITOR_SERVE_LOCAL`` and ``CKEDITOR_PKG_TYPE``, when you use other configuration variable,
-you have to call ``ckeditor.config()`` in template to make them register with CKEditor:
+Except for ``CKEDITOR_SERVE_LOCAL`` and ``CKEDITOR_PKG_TYPE``, when you use other configuration variables,
+you have to call ``ckeditor.config()`` in the template to make them register with CKEditor:
 
 .. code-block:: jinja
 
@@ -24,22 +24,22 @@ you have to call ``ckeditor.config()`` in template to make them register with CK
 Available Configuration
 ------------------------
 
-The configuration options available were listed below:
+The configuration options available are listed below:
 
 =============================== ======================= =========================================================================================================================================================================
             Name                    Default Value                                                                                  Info
 =============================== ======================= =========================================================================================================================================================================
-CKEDITOR_SERVE_LOCAL             ``False``               Flag used to set serve resources from local when use ``ckeditor.load()``, default to retrieve from CDN.
-CKEDITOR_PKG_TYPE                ``'standard'``          The package type of CKEditor, one of ``basic``, ``standard`` and ``full``.
+CKEDITOR_SERVE_LOCAL             ``False``               Flag used to enable serving resources from local when use ``ckeditor.load()``, default is to retrieve from CDN.
+CKEDITOR_PKG_TYPE                ``'standard'``          The package type of CKEditor, one of ``basic``, ``standard`` or ``full``.
 CKEDITOR_LANGUAGE                ``None``                The lang code string to set UI language in ISO 639 format, for example: ``zh``, ``en``, ``jp`` etc. Leave it unset to enable auto detection by user's browser setting.
 CKEDITOR_HEIGHT                  CKEditor default        The height of CKEditor textarea, in pixel.
 CKEDITOR_WIDTH                   CKEditor default        The width of CKEditor textarea, in pixel.
-CKEDITOR_FILE_UPLOADER           ``None``                The URL or endpoint that handle file upload.
-CKEDITOR_FILE_BROWSER            ``None``                The URL or endpoint that handle file browser.
+CKEDITOR_FILE_UPLOADER           ``None``                The URL or endpoint that handles file upload.
+CKEDITOR_FILE_BROWSER            ``None``                The URL or endpoint that handles file browser.
 CKEDITOR_ENABLE_CODESNIPPET      ``False``               Flag used to enable codesnippet plugin, the plugin must be installed (included in built-in resources).
 CKEDITOR_CODE_THEME              ``'monokai_sublime'``   Set code snippet highlight theme when codesnippet plugin was enabled.
 CKEDITOR_EXTRA_PLUGINS           ``[]``                  A list of extra plugins used in CKEditor, the plugins must be installed.
-CKEDITOR_ENABLE_CSRF             ``False``               Flag used to enable CSRF protect for image uploading, see :doc:`/plugins` for more details.
+CKEDITOR_ENABLE_CSRF             ``False``               Flag used to enable CSRF protection for image uploading, see :doc:`/plugins` for more details.
 CKEDITOR_UPLOAD_ERROR_MESSAGE    ``'Upload failed.'``    Default error message for failed upload.
 =============================== ======================= =========================================================================================================================================================================
 
@@ -58,18 +58,18 @@ Keep it mind that the proper syntax for each option is
 ``configuration name : configuration value``. You can use comma to
 separate multiple key-value pairs. See the list of available
 configuration settings on `CKEditor
-documentation <https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config%3E>`_.
+documentation <https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html>`_.
 
 
 Configuring Multiple Text Area
 --------------------------------
 
-If you need create multiple text area in one page, here are some tips:
+If you need to create multiple text areas in one page, here are some tips:
 
 Without Flask-WTF/WTForms
 ##########################
 
-Create two text area with different name and configure it with the name:
+Create two text areas with different name and configure them with a unique name:
 
 .. code-block:: jinja
 
@@ -88,8 +88,8 @@ Create two text area with different name and configure it with the name:
 With Flask-WTF/WTForms
 #######################
 
-When create multiple form with Flask-WTF/WTForms, you just need to create
-multiple ``CKEditorField`` field:
+When creating multiple forms with Flask-WTF/WTForms, you just need to create
+multiple ``CKEditorField`` fields:
 
 .. code-block:: python
 
@@ -119,10 +119,9 @@ In the template, you render them and configure them with the right name:
 
 Overwriting Global Configurations
 ----------------------------------
-Sometimes you may want to use different configuration for multiple text area, in this case, you can
-pass the specific keyword arguments into ``ckeditor.config()`` directly.
+Sometimes you may want to use a different configuration for multiple text areas, in this case, you can pass the specific keyword arguments into ``ckeditor.config()`` directly.
 
-The keyword arguments should mapping the corresponding configration variable in this way:
+The keyword arguments should map the corresponding configuration variables in this way:
 
 - CKEDITOR_LANGUAGE --> language
 - CKEDITOR_WIDTH --> width

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Flask-CKEditor
 ==============
 
 CKEditor integration for Flask, add support to image upload, code syntax
-highlight and more.
+highlighting and more.
 
 Contents
 ---------

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -7,16 +7,16 @@ Image Upload
 CKEditor >= 4.5
 ################
 
-The bulit-in CKEditor package include a `File
+The built-in CKEditor package includes a `File
 Browser <https://ckeditor.com/addon/filebrowser>`__ plugin. With this plugin,
-you can upload and insert image with image widget. You need set
-``CKEDITOR_FILE_UPLOADER`` to the URL or endpoint which handle upload
+you can upload and insert images with the image widget. You need to set
+``CKEDITOR_FILE_UPLOADER`` to the URL or endpoint which handles uploading
 files, and the upload view must return ``upload_success()`` call with
-the uploaded image's url. Usually, you also need to validate uploaded
+the url of the uploaded image. Usually, you also need to validate the uploaded
 image, then you can use ``upload_fail()`` to return an error message
-with ``message`` argument. If ``message`` was ``None``, the value in 
-configuration variable ``CKEDITOR_UPLOAD_ERROR_MESSAGE`` will be used, 
-default to ``Upload failed.``. Here is the full example:
+with the ``message`` argument. If ``message`` was ``None``, the value in 
+the configuration variable ``CKEDITOR_UPLOAD_ERROR_MESSAGE`` will be used, 
+defaults to ``Upload failed.``. Here is the full example:
 
 .. code-block:: python
 
@@ -33,17 +33,17 @@ default to ``Upload failed.``. Here is the full example:
    def upload():
        f = request.files.get('upload')
        # Add more validations here
-       extension = f.filename.split('.')[1].lower()
+       extension = f.filename.split('.')[-1].lower()
        if extension not in ['jpg', 'gif', 'png', 'jpeg']:
            return upload_fail(message='Image only!')
        f.save(os.path.join('/the/uploaded/directory', f.filename))
        url = url_for('uploaded_files', filename=f.filename)
        return upload_success(url=url)  # return upload_success call
 
-.. note:: The key pass to ``request.files.get()`` must be ``'upload'``,
+.. note:: The key passed to ``request.files.get()`` must be ``'upload'``,
 it's defined by CKEditor and it's not the name of the view function.
 
-In the template, you have to call ``ckeditor.config()`` to make configuration work:
+In the template, you have to call ``ckeditor.config()`` to make the configuration work:
 
 .. code-block:: jinja
 
@@ -55,8 +55,8 @@ In the template, you have to call ``ckeditor.config()`` to make configuration wo
     If you create the CKEditor through ``ckeditor.create()``, the default value (``ckeditor``) 
     will be used.
 
-Now you will find the ``Upload`` tab appear in image widget. Besides,
-you can drag and drop image directly into the editor area or copy and
+Now you will find the ``Upload`` tab appear in the image widget. Besides,
+you can drag and drop the image directly into the editor area or copy and
 paste the image (CKEditor >= 4.5).
 
 .. tip:: Check the demo application at ``examples/image-upload/``.
@@ -65,9 +65,7 @@ paste the image (CKEditor >= 4.5).
 CKEditor < 4.5
 ###############
 
-If the CKEditor version you use was under 4.5, you will need to use ``@ckeditor.uploader``
-to decorated the view function that handle the file upload. The upload view must return the 
-uploaded image's url. For example:
+If the CKEditor version you use is below 4.5, you will need to use ``@ckeditor.uploader`` to decorate the view function that handles the file upload. The upload view must return the url of the uploaded image. For example:
 
 .. code-block:: python
 
@@ -88,13 +86,12 @@ uploaded image's url. For example:
         url = url_for('uploaded_files', filename=f.filename)
         return url
 
-You can use configuration variable ``CKEDITOR_UPLOAD_ERROR_MESSAGE`` to customize the error 
-message when upload failed, default to ``Upload failed.``
+You can use the configuration variable ``CKEDITOR_UPLOAD_ERROR_MESSAGE`` to customize the error message when the upload failed, it defaults to ``Upload failed.``
 
-.. note:: The key pass to ``request.files.get()`` must be ``'upload'``,
+.. note:: The key passed to ``request.files.get()`` must be ``'upload'``,
 it's defined by CKEditor and it's not the name of the view function.
 
-In the template, you have to call ``ckeditor.config()`` to make configuration work:
+In the template, you have to call ``ckeditor.config()`` to make the configuration work:
 
 .. code-block:: jinja
 
@@ -103,18 +100,17 @@ In the template, you have to call ``ckeditor.config()`` to make configuration wo
 .. tip::
     When using Flask-WTF/WTForms, you have to pass the field name as
     ``name`` in ``ckeditor.config()``, for example ``ckeditor.config(name='description')``. 
-    If you create the CKEditor through ``ckeditor.create()``, the default value (``ckeditor``) 
-    will be used.
+    If you create the CKEditor through ``ckeditor.create()``, the default value (``ckeditor``) will be used.
 
-Now you will find the ``Upload`` tab appear in image widget.
+Now you will find the ``Upload`` tab appear in the image widget.
 
 
-CSRF Protect for Image Upload
-------------------------------
+CSRF Protection for Image Upload
+--------------------------------
 
 Required version: CKEditor >= 4.9.0
 
-The CSRF Protect feature was provided by Flask-WTF's ``CSRFProtect``
+The CSRF Protection feature was provided by Flask-WTF's ``CSRFProtect``
 extension, so you have to install Flask-WTF first:
 
 .. code-block:: bash
@@ -137,23 +133,15 @@ Then initialize the CSRFProtect extension:
 
     csrf = CSRFProtect(app)
 
-Make sure to set the secret key and set ``CKEDITOR_ENABLE_CSRF`` to
-True. Now all the image upload request will be protected!
+Make sure to set the secret key and set ``CKEDITOR_ENABLE_CSRF`` to True. Now all the image upload requests will be protected!
 
 
 Code Snippet Highlight
 ------------------------
 
-The bulit-in CKEditor package include a `Code
-Snippet <https://ckeditor.com/addon/codesnippet>`__ plugin. You need to set
-``CKEDITOR_ENABLE_CODESNIPPET`` to ``True`` to enable it. You can set
-the code theme through configuration option ``CKEDITOR_CODE_THEME``. The
-default theme was ``monokai_sublime``. See all available themes and the
-list of valid theme string on `this
-page <https://sdk.ckeditor.com/samples/codesnippet.html>`__.
+The built-in CKEditor package includes a `Code Snippet <https://ckeditor.com/addon/codesnippet>`__ plugin. You need to set ``CKEDITOR_ENABLE_CODESNIPPET`` to ``True`` to enable it. You can set the code theme through the configuration option ``CKEDITOR_CODE_THEME``. The default theme is ``monokai_sublime``. See all available themes and the list of valid theme strings on `this page <https://sdk.ckeditor.com/samples/codesnippet.html>`__.
 
-Another step was load code theme resources in the page you want to
-display the text:
+Another step is to load code theme resources on the page you want to display the text in:
 
 .. code-block:: jinja
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -12,7 +12,7 @@ Then go to http://127.0.0.1:5000 with your favourite browser.
 
 Aside from the basic example, there are four additional examples:
 
-- examples/image-upload: This example demonstrate how to support image upload in Flaks-CKEditor.
-- examples/codesnippet: This example demonstrate how to use Code Snippet plugin.
-- examples/without-flask-wtf: This example demonstrate how to use CKEditor without Flask-WTF.
-- examples/flask-admin: This example demonstrate how to use CKEditor for Flask-Admin.
+- examples/image-upload: This example demonstrates how to support image upload in Flaks-CKEditor.
+- examples/codesnippet: This example demonstrates how to use the Code Snippet plugin.
+- examples/without-flask-wtf: This example demonstrates how to use CKEditor without Flask-WTF.
+- examples/flask-admin: This example demonstrates how to use CKEditor for Flask-Admin.

--- a/flask_ckeditor/__init__.py
+++ b/flask_ckeditor/__init__.py
@@ -246,7 +246,7 @@ def upload_success(url, filename=''):
         from flask_ckeditor import upload_success
 
         app.config['CKEDITOR_FILE_UPLOADER'] = 'upload'  # this value can be endpoint or url
-        
+
 
         @app.route('/files/<path:filename>')
         def uploaded_files(filename):
@@ -274,7 +274,7 @@ def upload_fail(message=None):
 
         from flask import send_from_directory
         from flask_ckeditor import upload_success, upload_fail
-        
+
         app.config['CKEDITOR_FILE_UPLOADER'] = 'upload'  # this value can be endpoint or url
 
 

--- a/test_flask_ckeditor.py
+++ b/test_flask_ckeditor.py
@@ -61,12 +61,12 @@ class CKEditorTestCase(unittest.TestCase):
 
     def test_load(self):
         rv = self.ckeditor.load()
-        self.assertIn('//cdn.ckeditor.com', rv)
+        self.assertIn('https://cdn.ckeditor.com', rv)
         self.assertIn('standard/ckeditor.js', rv)
 
         current_app.config['CKEDITOR_PKG_TYPE'] = 'basic'
         rv = self.ckeditor.load()
-        self.assertIn('//cdn.ckeditor.com', rv)
+        self.assertIn('https://cdn.ckeditor.com', rv)
         self.assertIn('basic/ckeditor.js', rv)
 
     def test_local_resources(self):
@@ -83,7 +83,7 @@ class CKEditorTestCase(unittest.TestCase):
 
         rv = self.ckeditor.load()
         self.assertIn('/ckeditor/static/standard/ckeditor.js', rv)
-        self.assertNotIn('//cdn.ckeditor.com', rv)
+        self.assertNotIn('https://cdn.ckeditor.com', rv)
 
         current_app.config['CKEDITOR_PKG_TYPE'] = 'full'
         rv = self.ckeditor.load()
@@ -144,7 +144,7 @@ class CKEditorTestCase(unittest.TestCase):
     def test_ckeditor_field(self):
         response = self.client.get('/field')
         data = response.get_data(as_text=True)
-        self.assertIn('//cdn.ckeditor.com', data)
+        self.assertIn('https://cdn.ckeditor.com', data)
         self.assertIn('CKEDITOR.replace', data)
         self.assertIn('<textarea class="ckeditor', data)
         self.assertIn('name="body"', data)
@@ -161,7 +161,7 @@ class CKEditorTestCase(unittest.TestCase):
     def test_render_template(self):
         response = self.client.get('/')
         data = response.get_data(as_text=True)
-        self.assertIn('//cdn.ckeditor.com', data)
+        self.assertIn('https://cdn.ckeditor.com', data)
         self.assertIn('CKEDITOR.replace', data)
         self.assertIn('<textarea class="ckeditor"', data)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipsdist = true
 [testenv]
 commands = 
     coverage run --source=flask_ckeditor setup.py test
+deps =
+    coverage
 
 [testenv:coverage]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ commands =
     coverage run --source=flask_ckeditor setup.py test
 deps =
     coverage
+    flask_wtf
 
 [testenv:coverage]
 basepython = python2.7


### PR DESCRIPTION
- Fix a number of typos and spelling mistakes throughout the documentation.
- Fix URL scheme in the unittest.