### PR TITLE
Support to use the CodeSnippet plugin from CDN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 Release date: -
 
+- Support to pass ``standard-all`` and ``full-all`` as CKEditor package type.
+
 
 0.4.5
 -----

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -59,7 +59,14 @@ to True to use built-in resources. You can use ``custom_url`` to load your custo
    {{ ckeditor.load(custom_url=url_for('static', filename='ckeditor/ckeditor.js')) }}
 
 
-CKEditor provides three types of preset (i.e. ``basic``, ``standard`` and ``full``), this method defaults to load ``standard``.
+CKEditor provides five types of preset (see `comparison table <https://ckeditor.com/cke4/presets-all>`_ for the differences):
+
+- ``basic``
+- ``standard`` （default value）
+- ``full``
+- ``standard-all`` (only available from CDN)
+- ``full-all`` (only available from CDN)
+
 You can use `pkg_type` parameter or ``CKEDITOR_PKG_TYPE`` configuration variable to set the package type. For example:
 
 .. code-block:: jinja

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,7 +48,7 @@ The configuration options available are listed below:
             Name                    Default Value                                                                                  Info
 =============================== ======================= =========================================================================================================================================================================
 CKEDITOR_SERVE_LOCAL             ``False``               Flag used to enable serving resources from local when use ``ckeditor.load()``, default is to retrieve from CDN.
-CKEDITOR_PKG_TYPE                ``'standard'``          The package type of CKEditor, one of ``basic``, ``standard`` or ``full``.
+CKEDITOR_PKG_TYPE                ``'standard'``          The package type of CKEditor, one of ``basic``, ``standard``, ``full``, ``standard-all`` and ``full-all``. The last two options only available from CDN.
 CKEDITOR_LANGUAGE                ``None``                The lang code string to set UI language in ISO 639 format, for example: ``zh``, ``en``, ``jp`` etc. Leave it unset to enable auto detection by user's browser setting.
 CKEDITOR_HEIGHT                  CKEditor default        The height of CKEditor textarea, in pixel.
 CKEDITOR_WIDTH                   CKEditor default        The width of CKEditor textarea, in pixel.

--- a/test_flask_ckeditor.py
+++ b/test_flask_ckeditor.py
@@ -92,6 +92,14 @@ class CKEditorTestCase(unittest.TestCase):
         rv = self.ckeditor.load()
         self.assertIn('/ckeditor/static/full/ckeditor.js', rv)
 
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'standard-all'
+        rv = self.ckeditor.load()
+        self.assertIn('/ckeditor/static/standard/ckeditor.js', rv)
+
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'full-all'
+        rv = self.ckeditor.load()
+        self.assertIn('/ckeditor/static/standard/ckeditor.js', rv)
+
     def test_config(self):
         current_app.config['CKEDITOR_LANGUAGE'] = 'zh'
         current_app.config['CKEDITOR_HEIGHT'] = '300'
@@ -228,3 +236,19 @@ class CKEditorTestCase(unittest.TestCase):
         data = response.get_data(as_text=True)
         self.assertIn('class="ckeditor', data)
         self.assertNotIn('document.getElementById("ckeditor").classList.remove("ckeditor")', data)
+
+    def test_codesnippet_plugin_from_cdn(self):
+        current_app.config['CKEDITOR_ENABLE_CODESNIPPET'] = True
+        current_app.config['CKEDITOR_SERVE_LOCAL'] = False
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'basic'
+        rv = self.ckeditor.load()
+        self.assertIn('standard-all', rv)
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'standard'
+        rv = self.ckeditor.load()
+        self.assertIn('standard-all', rv)
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'full'
+        rv = self.ckeditor.load()
+        self.assertIn('standard-all', rv)
+        current_app.config['CKEDITOR_PKG_TYPE'] = 'full-all'
+        rv = self.ckeditor.load()
+        self.assertIn('full-all', rv)


### PR DESCRIPTION
This PR will:

- Allow passing `standard-all` and `full-all` as the package name.
- Use `standard-all` if the user enables the CodeSnippet plugin and set `CKEDITOR_SERVE_LOCAL` to False.

fixes #47